### PR TITLE
Use env variables instead of placeholders

### DIFF
--- a/src/discordbot.py
+++ b/src/discordbot.py
@@ -94,7 +94,7 @@ async def update_leaderboard():
     channel_id = int(os.getenv('DISCORD_CHANNEL_ID')) or 0
     if channel_id == 0:
         print("Warning: No DISCORD_CHANNEL_ID environment variable set. Defaulting to 0.")
-    channel_id = client.get_channel(channel_id)
+    channel = client.get_channel(channel_id)
 
     rankings = playertracker.compute_ranks(r)
     leaderboard = playertracker.compute_leaderboard(rankings, r)

--- a/src/discordbot.py
+++ b/src/discordbot.py
@@ -1,3 +1,4 @@
+import os
 import discord
 import json
 
@@ -8,9 +9,10 @@ import playertracker
 
 intents = discord.Intents.all()
 intents.message_content = True
-# Set up your discord bot token
-TOKEN = ""
-
+# Set up your discord bot token 'export DISCORD_BOT_TOKEN="blabla"'
+TOKEN = os.getenv('DISCORD_BOT_TOKEN') or ""
+if TOKEN == "":
+   print("Warning: No DISCORD_TOKEN environment variable set.")
 #Create a client instance
 client = discord.Client(intents=intents)
 
@@ -88,14 +90,23 @@ async def on_ready():
    await update_leaderboard()
 
 async def update_leaderboard():
-    channel = client.get_channel(0) #replace with channel id
+    # Set up your discord channel id 'export DISCORD_CHANNEL_ID="123"'
+    channel_id = int(os.getenv('DISCORD_CHANNEL_ID')) or 0
+    if channel == 0:
+        print("Warning: No DISCORD_CHANNEL_ID environment variable set. Defaulting to 0.")
+    channel = client.get_channel(channel_id)
 
     rankings = playertracker.compute_ranks(r)
     leaderboard = playertracker.compute_leaderboard(rankings, r)
 
     view = LeaderboardView(leaderboard)
     body = tabulate(leaderboard[0:25], headers=["#", "RSN", "Rank", "Points", "EHB + EHP"])
-    msg = await channel.fetch_message(0) #replace with msg
+
+    # Set up your discord message id 'export DISCORD_MESSAGE_ID="123"'
+    message_id = int(os.getenv('DISCORD_MESSAGE_ID')) or 0
+    if message_id == 0:
+        print("Warning: No DISCORD_MESSAGE_ID environment variable set. Defaulting to 0.")
+    msg = await channel.fetch_message(message_id)
     await msg.edit(content="```{}```".format(body), view=view)
 
 # Run the client

--- a/src/discordbot.py
+++ b/src/discordbot.py
@@ -92,9 +92,9 @@ async def on_ready():
 async def update_leaderboard():
     # Set up your discord channel id 'export DISCORD_CHANNEL_ID="123"'
     channel_id = int(os.getenv('DISCORD_CHANNEL_ID')) or 0
-    if channel == 0:
+    if channel_id == 0:
         print("Warning: No DISCORD_CHANNEL_ID environment variable set. Defaulting to 0.")
-    channel = client.get_channel(channel_id)
+    channel_id = client.get_channel(channel_id)
 
     rankings = playertracker.compute_ranks(r)
     leaderboard = playertracker.compute_leaderboard(rankings, r)


### PR DESCRIPTION
Use env variables for discord bot id, channel and message id's instead of manually adding them to code. This will make updating bot easier since no manual work should be required